### PR TITLE
Fix package.json dependency declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "url": "https://github.com/zoom/websdk/issues"
   },
   "dependencies": {
-    "react": ">16.13.1",
-    "react-dom": ">16.13.1",
     "redux": "^3.7.2",
     "react-redux": "^7.2.9",
     "lodash": "^4.17.21",
     "redux-thunk": "^2.4.2"
+  },
+  "peerDependencies": {
+    "react": ">16.13.1",
+    "react-dom": ">16.13.1"
   },
   "files": [
     "dist/*",

--- a/package.json
+++ b/package.json
@@ -19,20 +19,12 @@
     "url": "https://github.com/zoom/websdk/issues"
   },
   "dependencies": {
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "redux": "3.7.2",
-    "react-redux": "7.2.9",
+    "react": ">16.13.1",
+    "react-dom": ">16.13.1",
+    "redux": "^3.7.2",
+    "react-redux": "^7.2.9",
     "lodash": "^4.17.21",
-    "redux-thunk": "2.4.2"
-  },
-  "peerDependencies": {
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "redux": "3.7.2",
-    "react-redux": "7.2.9",
-    "lodash": "^4.17.21",
-    "redux-thunk": "2.4.2"
+    "redux-thunk": "^2.4.2"
   },
   "files": [
     "dist/*",


### PR DESCRIPTION
There are two issues with the current structure of the package.json file that cause friction for consumers of this package.

1. The package.json file declares identical `dependencies` and `peerDependencies` objects. This causes confusion as to what packages are actually being installed, as `dependencies` causes downstream consumers to download the requirements while `peerDependencies` does not but rather causes package managers to throw warnings if the package requested does not appear as a top-level dependency of the consuming package itself. (Sorry that was the word "package" an awful lot in there - starting to hit semantic exhaustion.) **The TLDR here is each package should either be declared as a dependency OR as a peer dependency, but not both.** I've opted to fix this in my suggestion by removing the peer dependencies other than react because my project does not use redux or lodash, but if your intention would be that consuming apps should explicitly install those packages then they also should be moved to peer dependencies and noted in the documentation.
2. The package.json file declares a precise, fixed version for every dependency (other than lodash). This is risky because it can cause multiple copies of a dependency like `react`, which is known to cause annoying bugs due to name collisions. Instead, flexible packages like react should be declared with version ranges (here I've suggested using `>` your specified version for react, and `^` the specified version for redux).

I'm aware that because this SDK is, unfortunately, closed source that it's unlikely you can apply this patch directly. However, since this is causing us active issues in our usage of the SDK, I'm hoping you can incorporate this to your closed source and then issue an update that uses it. I would really appreciate being able to loosen some of our overriding `resolutions` definitions to fix type conflicts between your dependencies and our own.