### PR TITLE
Fix type of userId

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1088,7 +1088,7 @@ function makeHost(args: {
   /**
    * User ID.
    */
-  userId: boolean;
+  userId: number;
   /**
    * Callback function on success.
    */


### PR DESCRIPTION
The type of `userId` argument in `makeHost` function is `boolean`. Fixed it by changing it to `number`